### PR TITLE
App connector implementation (dynamic approach)

### DIFF
--- a/packages/core/src/ConnectorTypes.ts
+++ b/packages/core/src/ConnectorTypes.ts
@@ -14,4 +14,5 @@ export interface ConnectorInterface {
   repoForApp?(appAddress: string): Promise<Repo>
   appByAddress?(appAddress: string): Promise<App>
   roleById?(roleId: string): Promise<Role>
+  getAppState?(appAlias: string, selectorAlias: string, args: any[]): Promise<any>
 }

--- a/packages/core/src/wrappers/App.ts
+++ b/packages/core/src/wrappers/App.ts
@@ -57,4 +57,8 @@ export default class App extends BaseWrapper implements AppData {
   async repo(): Promise<Repo> {
     return this._connector.repoForApp!(this.address)
   }
+
+  async getState(selectorAlias: string, args: any[] = []): Promise<any> {
+    return this._connector.getAppState!(this.name!, selectorAlias, args)
+  }
 }

--- a/packages/core/src/wrappers/App.ts
+++ b/packages/core/src/wrappers/App.ts
@@ -1,5 +1,5 @@
 import Repo from "./Repo"
-import Base from "./Base"
+import BaseWrapper from "./BaseWrapper"
 import { ConnectorInterface } from "../ConnectorTypes"
 
 // TODO: Implement all properties and methods from the API spec (https://github.com/aragon/plumbery/blob/master/docs/app.md).
@@ -39,7 +39,7 @@ export interface AppData {
   isForwarder: boolean
 }
 
-export default class App extends Base implements AppData {
+export default class App extends BaseWrapper implements AppData {
   readonly name?: string
   readonly address!: string
   readonly appId!: string

--- a/packages/core/src/wrappers/Base.ts
+++ b/packages/core/src/wrappers/Base.ts
@@ -7,10 +7,13 @@ export default class Base {
     this._connector = connector
   }
 
-  public describe(): string {
-    return Object.getOwnPropertyNames(this)
+  public toString(): string {
+    const render = {}
+
+    Object.getOwnPropertyNames(this)
       .filter(prop => !prop.includes('_'))
-      .map(prop => `  ${prop}: ${(this as any)[prop]}`)
-      .join('\n')
+      .map(prop => (render as any)[prop] = (this as any)[prop])
+
+    return JSON.stringify(render, null, 2)
   }
 }

--- a/packages/core/src/wrappers/BaseWrapper.ts
+++ b/packages/core/src/wrappers/BaseWrapper.ts
@@ -1,6 +1,6 @@
 import { ConnectorInterface } from "../ConnectorTypes";
 
-export default class Base {
+export default class BaseWrapper {
   protected _connector: ConnectorInterface
 
   constructor(connector: ConnectorInterface) {

--- a/packages/core/src/wrappers/Permission.ts
+++ b/packages/core/src/wrappers/Permission.ts
@@ -1,4 +1,4 @@
-import Base from "./Base"
+import BaseWrapper from "./BaseWrapper"
 import App from './App'
 import Role from './Role'
 import { ConnectorInterface } from "../ConnectorTypes"
@@ -17,7 +17,7 @@ export interface PermissionData {
   id: string
 }
 
-export default class Permission extends Base implements PermissionData {
+export default class Permission extends BaseWrapper implements PermissionData {
   readonly app!: string
   readonly entity!: string
   readonly role!: string

--- a/packages/core/src/wrappers/Repo.ts
+++ b/packages/core/src/wrappers/Repo.ts
@@ -1,4 +1,4 @@
-import Base from "./Base"
+import BaseWrapper from "./BaseWrapper"
 import { ConnectorInterface } from "../ConnectorTypes"
 
 // TODO: Implement all properties and methods from the API spec (https://github.com/aragon/plumbery/blob/master/docs/repo.md).
@@ -18,7 +18,7 @@ export interface RepoData {
   address: string
 }
 
-export default class Repo extends Base implements RepoData {
+export default class Repo extends BaseWrapper implements RepoData {
   readonly name!: string
   readonly address!: string
 

--- a/packages/core/src/wrappers/Role.ts
+++ b/packages/core/src/wrappers/Role.ts
@@ -1,4 +1,4 @@
-import Base from "./Base"
+import BaseWrapper from "./BaseWrapper"
 import { ConnectorInterface } from "../ConnectorTypes"
 
 // TODO: Implement all properties and methods from the API spec (https://github.com/aragon/plumbery/blob/master/docs/role.md).
@@ -14,7 +14,7 @@ export interface RoleData {
   bytes: string
 }
 
-export default class Role extends Base implements RoleData {
+export default class Role extends BaseWrapper implements RoleData {
   readonly name!: string
   readonly id!: string
   readonly params!: string

--- a/packages/organization-viewer-cli/src/index.ts
+++ b/packages/organization-viewer-cli/src/index.ts
@@ -6,6 +6,8 @@ import {
 } from 'plumbery-core'
 import Connection from 'plumbery-core/dist/Connection'
 
+const DAO_SUBGRAPH_URL = 'https://api.thegraph.com/subgraphs/name/0xgabi/dao-subgraph-rinkeby'
+const VOTING_SUBGRAPH_URL = 'https://api.thegraph.com/subgraphs/name/ajsantander/voting-subgraph'
 const ORG_ADDRESS = '0x00e45b9918297037fe6585c2a1e53e8801f562f4'
 
 let app
@@ -39,7 +41,7 @@ async function main() {
   if (app) { console.log(app.toString()) }
 
   console.log('\nA role from a permission:')
-  const role = await permissions[1].getRole()
+  const role = await permissions[2].getRole()
   console.log(role.toString())
 }
 
@@ -53,9 +55,10 @@ function initConnection(): Connection {
     connector: [
       'thegraph',
       {
-        daoSubgraphUrl:
-          'https://api.thegraph.com/subgraphs/name/0xgabi/dao-subgraph-rinkeby',
-        appSubgraphUrl: () => '',
+        daoSubgraphUrl: DAO_SUBGRAPH_URL,
+        appSubgraphUrls: {
+          voting: VOTING_SUBGRAPH_URL
+        }
       },
     ],
     signer: {},

--- a/packages/organization-viewer-cli/src/index.ts
+++ b/packages/organization-viewer-cli/src/index.ts
@@ -6,46 +6,41 @@ import {
 } from 'plumbery-core'
 import Connection from 'plumbery-core/dist/Connection'
 
-const ORG_ADDRESS = '0x00018d22ece8b2ea4e9317b93f7dff67385693d8'
+const ORG_ADDRESS = '0x00e45b9918297037fe6585c2a1e53e8801f562f4'
+
+let app
 
 async function main() {
-  let app
-
   const connection = initConnection()
-
   const org = connection.organization(ORG_ADDRESS)
 
-  // Retrieve all the permissions of an org.
+  console.log('\nPermissions:')
   const permissions = await org.permissions()
-  console.log(`\nPermissions:\n${permissions.map(
-    (p: Permission) => p.describe()
-  ).join('\n')}`)
+  permissions.map((permission: Permission) => console.log(permission.toString()))
 
-  // Retrieve all the apps of an org.
+  console.log('\nApps:')
   const apps = await org.apps()
-  console.log(`\nApps:\n${apps.map(
-    (app: App) => app.describe()
-  ).join('\n')}`)
-  app = apps[0]
-  console.log(`\nFirst app:\n${app.describe()}`)
+  apps.map((app: App) => console.log(app.toString()))
 
-  // Retrieve a repo from an app.
+  console.log('\nA voting app:')
+  app = apps.find((app: App) => app.name == 'voting')!
+  console.log(app.toString())
+
+  console.log('\nA repo from an app:')
   const repo = await app.repo()
-  console.log(`\nRepo:\n${repo.describe()}`)
+  console.log(repo.toString())
 
-  // Retrieve an app by address.
+  console.log('\nAn app by address:')
   app = await org.app(apps[1].address)
-  console.log(`\nApp by address:\n${app.describe()}`)
+  console.log(app.toString())
 
-  // Retrieve an app from a permission.
+  console.log('\nAn app from a permission:')
   app = await permissions[1].getApp()
-  if (app) {
-    console.log(`\nApp from permission:\n${app.describe()}`)
-  }
+  if (app) { console.log(app.toString()) }
 
-  // Retrieve a role from a permission.
+  console.log('\nA role from a permission:')
   const role = await permissions[1].getRole()
-  console.log(`\nRole from permission:\n${role.describe()}`)
+  console.log(role.toString())
 }
 
 function initConnection(): Connection {


### PR DESCRIPTION
ConnectorInterface exposes a new function `async getAppState(appAlias: string, selectorAlias: string, args: any[]): Promise<any>` which allows to dynamically query the state of an app, for example:

```
  const voting = apps.find((app: App) => app.name == 'voting')
  const votes = await voting!.getState('votes')
  console.log(votes
```

This requires the user to specify the details of how this dynamic data fetch is done, when setting up the connector:

```
const votingAppSelectors = {
  votes: {
    query: gql`
      query {
        votes {
          id
          creator
          metadata
          executed
        }
      }
    `,
    parser: (data: any) => {
      return data
    }
  }
}

aragonConnect({
    connector: [
      'thegraph',
      {
        daoSubgraphUrl: DAO_SUBGRAPH_URL,
        appConnectors: {
          voting: {
            subgraphUrl: VOTING_SUBGRAPH_URL,
            selectors: votingAppSelectors
          }
        }
      },
    ],
    signer: {},
  })
```