### PR TITLE
Fix typos in documentation on intent parameters

### DIFF
--- a/docs/intent.md
+++ b/docs/intent.md
@@ -10,7 +10,7 @@ Get all the possible transaction paths for a given address. This can be useful t
 
 | Name         | Type                | Description                                                                                      |
 | ------------ | ------------------- | ------------------------------------------------------------------------------------------------ |
-| `address`    | `String`            | The account that will sign the transaction.                                                      |
+| `account`    | `String`            | The account that will sign the transaction.                                                      |
 | `options`    | `Object`            | Options object.                                                                                  |
 | `options.as` | `String`            | Address of an Aragon organization, or its agent app, through which the paths should get created. |
 | returns      | `TransactionPath[]` | Array of all the possible transaction paths.                                                     |
@@ -23,7 +23,7 @@ This is an easier way to do `intent.paths(account, options)[0].transactions`
 
 | Name         | Type                   | Description                                                                                      |
 | ------------ | ---------------------- | ------------------------------------------------------------------------------------------------ |
-| `address`    | `String`               | The account that will sign the transaction.                                                      |
+| `account`    | `String`               | The account that will sign the transaction.                                                      |
 | `options`    | `Object`               | Options object.                                                                                  |
 | `options.as` | `String`               | Address of an Aragon organization, or its agent app, through which the paths should get created. |
 | returns      | `TransactionRequest[]` | The transactions corresponding to the shortest transaction path.                                 |


### PR DESCRIPTION
It seems that the `account` parameter was changed to `address` in the parameter list below the methods documented for intents