### PR TITLE
Voting Subgraph: Add timestamps and transaction hashes to votes and casts

### DIFF
--- a/packages/voting-subgraph/schema.graphql
+++ b/packages/voting-subgraph/schema.graphql
@@ -1,11 +1,13 @@
 type Vote @entity {
   id: ID!
+  transactionHash: Bytes!
   orgAddress: Bytes!
   appAddress: Bytes!
   creator: Bytes!
   metadata: String!
   open: Boolean!
   executed: Boolean!
+  timestamp: BigInt!
   startDate: BigInt!
   snapshotBlock: BigInt!
   supportRequiredPct: BigInt!
@@ -20,6 +22,8 @@ type Vote @entity {
 
 type Cast @entity {
   id: ID!
+  transactionHash: Bytes!
+  timestamp: BigInt!
   voteNum: BigInt!
   voter: Bytes!
   supports: Boolean!

--- a/packages/voting-subgraph/src/Voting.ts
+++ b/packages/voting-subgraph/src/Voting.ts
@@ -88,11 +88,15 @@ function _populateVoteDataFromContract(vote: VoteEntity, appAddress: Address, vo
 }
 
 function _populateVoteDataFromEvent(vote: VoteEntity, event: StartVoteEvent): void {
+  vote.transactionHash = event.transaction.hash
+  vote.timestamp = event.block.timestamp
   vote.creator = event.params.creator
   vote.metadata = event.params.metadata
 }
 
 function _populateCastDataFromEvent(cast: CastEntity, event: CastVoteEvent, voteNum: BigInt): void {
+  cast.transactionHash = event.transaction.hash
+  cast.timestamp = event.block.timestamp
   cast.voteNum = voteNum
   cast.voter = event.params.voter
   cast.supports = event.params.supports


### PR DESCRIPTION
Adds timestamps and transaction hashes to each `Vote` and `Cast` entity, as discussed with @ajsantander offline.

Didn't really add a lot of ordering to the schema or the entity assignment as it seemed there was not any.